### PR TITLE
Maintenance

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -40,7 +40,7 @@ $(APP_NAME).bin: $(SRC) $(INC)
 	$(CC) $(CFLAGS) -DFIRMWARE_VERSION="\"$(APP_NAME)_$(FIRMWARE_VERSION)\"" -DSAMPLE_FREQ=$(SAMPLE_FREQ) $(SRC)
 	@mkdir -p bin
 	@mv *.o* bin/
-	$(LD) $(LDFLAGS) $(LPATH) -o bin/$(APP_NAME).out -Map bin/$(APP_NAME).map bin/*.o* \
+	$(LD) $(LDFLAGS) $(LPATH) -o bin/$(APP_NAME).out -Map bin/$(APP_NAME).map bin/*.o \
 		$(STARTERWARE_LIB) -lc -lgcc $(STARTERWARE_LIB) $(RUNTIMELIB) $(EXTRA_LIBS) -T $(APP_ROOT)/build/loader.lds
 	$(BIN) $(BINFLAGS) bin/$(APP_NAME).out $(APP_NAME).bin 
 #@git diff --exit-code --quiet || (echo; echo "*** WARNING: uncommitted changes; firmware version might be wrong! ***")

--- a/build/Makefile
+++ b/build/Makefile
@@ -36,7 +36,7 @@ INC=$(wildcard *.h) $(APP_ROOT)/include/*.h
 FIRMWARE_VERSION=$(shell git rev-parse HEAD)
 
 # Build this package
-$(APP_NAME).bin: $(SRC) $(INC)
+$(APP_NAME).bin: Makefile $(SRC) $(INC)
 	$(CC) $(CFLAGS) -DFIRMWARE_VERSION="\"$(APP_NAME)_$(FIRMWARE_VERSION)\"" -DSAMPLE_FREQ=$(SAMPLE_FREQ) $(SRC)
 	@mkdir -p bin
 	@mv *.o* bin/


### PR DESCRIPTION
The linker error when building rig binaries stems from incorrect invokation of linker. The output file which it is supposed to create should not be matched by its input pattern.

The second change is related to changing sampling frequency in the rig make file. I've made the make file a dependency of the rig binary file target, so now every time the make file is updated, the rig binary is rebuilt.

Both are one line changes. Hopefully, it will make it more convenient to work with the code.