### PR TITLE
Eliminate left shift overflow warning

### DIFF
--- a/src/ad760x.c
+++ b/src/ad760x.c
@@ -103,7 +103,7 @@
 #define SPI1_D1   GPIO_3_16
 
 #define AD760X_SIGN_MASK   (1 << (AD760X_BIT_COUNT - 1))
-#define AD760X_SIGN_EXT    (0xFFFF << AD760X_BIT_COUNT)
+#define AD760X_SIGN_EXT    (0xFFFFu << AD760X_BIT_COUNT)
 
 volatile int ad760xBuffer[AD760X_CHANNEL_COUNT];
 volatile int ad760xBufferReady = 0;


### PR DESCRIPTION
The warning kept annoying me, so I investigated its source and found how to fix it.

```
../..//src/ad760x.c: In function 'ad760xMcSPIIsr':
../..//src/ad760x.c:108:50: warning: result of '65535 << 18' requires 35 bits to represent, but 'int' only has 32 bits [-Wshift-overflow]
#define AD760X_SIGN_EXT (0xFFFF << AD760X_BIT_COUNT)
^
../..//src/ad760x.c:403:65: note: in expansion of macro 'AD760X_SIGN_EXT'
ad760xBuffer[i] = (j & AD760X_SIGN_MASK) ? (j | AD760X_SIGN_EXT) : j;
```

The C99 standard actually allows this operation, provided the left operand is _unsigned_. So, by adding a suffix (```0xFFFF``` becomes ```0xFFFFu```) to indicate that the numeric constant is of unsigned type, the compiler is satisfied and the source of warning is removed.